### PR TITLE
fix: add missing s3 tables permissions

### DIFF
--- a/terraform/s3_table_bucket/variables.tf
+++ b/terraform/s3_table_bucket/variables.tf
@@ -33,6 +33,7 @@ variable "table_bucket_name" {
   }
 }
 
+# See https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-setting-up.html#s3-tables-actions
 variable "table_bucket_policy_actions" {
   description = "List of actions for the table bucket policy - grants all necessary permissions"
   type        = list(string)
@@ -41,6 +42,7 @@ variable "table_bucket_policy_actions" {
     "s3tables:CreateTableBucket",
     "s3tables:GetTableBucket",
     "s3tables:DeleteTableBucket",
+    "s3tables:ListTableBuckets",
     # Namespace management
     "s3tables:CreateNamespace",
     "s3tables:GetNamespace",
@@ -69,9 +71,11 @@ variable "table_bucket_policy_actions" {
     "s3tables:PutTableBucketMaintenanceConfiguration",
     "s3tables:GetTableMaintenanceConfiguration",
     "s3tables:PutTableMaintenanceConfiguration",
+    "s3tables:GetTableMaintenanceJobStatus",
     # Encryption configuration
     "s3tables:GetTableBucketEncryption",
     "s3tables:PutTableBucketEncryption",
+    "s3tables:DeleteTableBucketEncryption",
     "s3tables:GetTableEncryption",
     "s3tables:PutTableEncryption"
   ]

--- a/terraform/s3_table_bucket/variables.tfvars.example
+++ b/terraform/s3_table_bucket/variables.tfvars.example
@@ -5,12 +5,13 @@ table_bucket_name                            = "s3-tables-bucket" # Must be glob
 terraform_remote_state_bucket                = "terraform-remote-state-bucket" # Name of the S3 bucket for Terraform state files
 terraform_remote_state_github_actions_s3_key = "key/to/terraform.tfstate" # S3 key for the Terraform remote state of the GitHub Actions role created
 
-# S3 Tables Policy Actions - Complete list of permissions for GitHub Actions
+# See https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-setting-up.html#s3-tables-actions
 table_bucket_policy_actions = [
   # Table bucket management
   "s3tables:CreateTableBucket",
   "s3tables:GetTableBucket",
   "s3tables:DeleteTableBucket",
+  "s3tables:ListTableBuckets",
   # Namespace management
   "s3tables:CreateNamespace",
   "s3tables:GetNamespace",
@@ -39,9 +40,11 @@ table_bucket_policy_actions = [
   "s3tables:PutTableBucketMaintenanceConfiguration",
   "s3tables:GetTableMaintenanceConfiguration",
   "s3tables:PutTableMaintenanceConfiguration",
+  "s3tables:GetTableMaintenanceJobStatus",
   # Encryption configuration
   "s3tables:GetTableBucketEncryption",
   "s3tables:PutTableBucketEncryption",
+  "s3tables:DeleteTableBucketEncryption",
   "s3tables:GetTableEncryption",
   "s3tables:PutTableEncryption"
 ]


### PR DESCRIPTION
## Description

This pull requests completed coverage of all [S3 Table actions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-setting-up.html#s3-tables-actions) by adding missing actions

## Related Issue(s)

## Changelog

- [ ] Python: code changes
- [ ] Python: docs/config updates
- [x] Terraform: infra changes
- [ ] Other: ___________________

## Checklist

### Python

- [ ] Unit tests added/updated as needed
- [ ] Tests pass locally
- [ ] Linting passes
- [ ] Typing passes

### Terraform (only if infra touched)

- [x] `terraform fmt` and `validate` pass
- [x] `terraform plan` reviewed (no unintended changes)
- [ ] No secrets committed; sensitive vars handled via CI or state

### General

- [ ] Documentation updated (README/CHANGELOG/config)
- [ ] No breaking changes without migration notes
