### PR TITLE
style: rename table bucket and namespace

### DIFF
--- a/terraform/s3_table_bucket/variables.tf
+++ b/terraform/s3_table_bucket/variables.tf
@@ -25,7 +25,7 @@ variable "terraform_remote_state_github_actions_s3_key" {
 variable "table_bucket_name" {
   description = "Name of the S3 Tables bucket"
   type        = string
-  default     = "tbills-scraper-s3-tables"
+  default     = "financial-data"
 
   validation {
     condition     = can(regex("^[a-z0-9][a-z0-9-]*[a-z0-9]$", var.table_bucket_name))
@@ -85,7 +85,7 @@ variable "table_bucket_policy_actions" {
 variable "namespace" {
   description = "Name of the namespace to create"
   type        = string
-  default     = "scraper"
+  default     = "treasury_bills"
 
   validation {
     condition = (


### PR DESCRIPTION
## Description

This pull request simply renames the s3 table bucket and namespace.

## Related Issue(s)

## Changelog

- [ ] Python: code changes
- [ ] Python: docs/config updates
- [x] Terraform: infra changes
- [ ] Other: ___________________

## Checklist

### Python

- [ ] Unit tests added/updated as needed
- [ ] Tests pass locally
- [ ] Linting passes
- [ ] Typing passes

### Terraform (only if infra touched)

- [x] `terraform fmt` and `validate` pass
- [x] `terraform plan` reviewed (no unintended changes)
- [ ] No secrets committed; sensitive vars handled via CI or state

### General

- [ ] Documentation updated (README/CHANGELOG/config)
- [ ] No breaking changes without migration notes
