### PR TITLE
feat: deploy github pages with workflow

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -1,0 +1,47 @@
+name: Deploy Static Content to Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout repository
+        id: checkout-repo
+        uses: actions/checkout@v4
+
+      - name: Setup pages
+        id: setup-pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './docs'
+
+      - name: Deploy to github pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Description

Add a **Deploy Static Content to Pages** workflow to deploy static content in `docs/` without needing to set up a publish source. 

**What changed**

* Trigger pages deploys only on `push` to `main` **when files under `docs/**` change**
* Keep manual trigger via `workflow_dispatch`

## Related Issue(s)

## Changelog

* [ ] Python: code changes
* [ ] Python: docs/config updates
* [ ] Terraform: infra changes
* [x] Other: CI — limit GitHub Pages deploys to `docs/**` changes on `main`

## Checklist

### Python

* [ ] Unit tests added/updated as needed
* [ ] Tests pass locally
* [ ] Linting passes
* [ ] Typing passes

### Terraform (only if infra touched)

* [ ] `terraform fmt` and `validate` pass
* [ ] `terraform plan` reviewed (no unintended changes)
* [ ] No secrets committed; sensitive vars handled via CI or state

### General

* [ ] Documentation updated (README/CHANGELOG/config)
* [x] No breaking changes without migration notes
