### PR TITLE
refactor: handle empty response content

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 
 import polars as pl
 from loguru import logger
@@ -12,7 +13,12 @@ APP_DATA_DIR: Path = PROJECT_ROOT_DIR / "app" / "data"
 def main() -> int:
     aws_settings: AWSSettings = AWSSettings()
     tbills_scraper: TreasuryBillScraper = TreasuryBillScraper(settings=aws_settings)
-    data: pl.DataFrame = tbills_scraper.scrape_treasury_data()
+    data: Optional[pl.DataFrame] = tbills_scraper.scrape_treasury_data()
+
+    if data is None:
+        logger.info("No data scraped, returning early")
+        return 0
+
     APP_DATA_DIR.mkdir(parents=True, exist_ok=True)
     logger.info("Saving scraped data to local app data directory")
     data.select(["maturity", "yield_pct"]).write_csv(APP_DATA_DIR / "daily_yields.csv")

--- a/src/tbills.py
+++ b/src/tbills.py
@@ -278,15 +278,16 @@ class TreasuryBillScraper(object):
             region_name=self.settings.aws_region
         )
 
-    def scrape_treasury_data(self) -> pl.DataFrame:
+    def scrape_treasury_data(self) -> Optional[pl.DataFrame]:
         """
         Fetch the latest treasury daily bill bond-equivalent yields.
 
         Returns
         -------
-        pl.DataFrame
+        Optional[pl.DataFrame]
             DataFrame (long-format) containing the latest treasury yields
-            for each maturity bucket: 4, 6, 8, 13, 17, 26, 52 weeks.
+            for each maturity bucket: 4, 6, 8, 13, 17, 26, 52 weeks; or None
+            if no data is available.
 
         Raises
         ------
@@ -305,6 +306,10 @@ class TreasuryBillScraper(object):
         logger.info(f"Fetching data from {url}")
         response: requests.Response = requests.get(url, timeout=30)
         response.raise_for_status()
+
+        if not response.content:
+            logger.warning("Empty or invalid response received from Treasury website")
+            return None
 
         data: pl.DataFrame = (
             pl.scan_csv(


### PR DESCRIPTION
## Description

This pull request improves error handling in the scraper, handling empty responses from the Treasury website. Previously, when the website returned an empty or invalid response, the application would crash with a `NoDataError` during CSV processing. Now it returns `None` and logs a warning, allowing the application to exit gracefully.

This can happen whenever there is no data published for the day.

## Related Issue(s)

## Changelog

- [x] Python: code changes

## Changes

- Added null check for Treasury API response content in `tbills.py`
- Added early return pattern in `main.py` when no data is scraped

## Checklist

### Python

- [ ] Unit tests pass locally
- [x] Linting passes
- [x] Typing passes
- [x] No breaking changes
