### PR TITLE
refactor: terraform module finetune

### DIFF
--- a/terraform/github_action_oidc/iam.tf
+++ b/terraform/github_action_oidc/iam.tf
@@ -21,7 +21,7 @@ locals {
 
 # IAM role for workflow
 resource "aws_iam_role" "github_actions_role" {
-  name = "${var.project_prefix}_github_actions_role"
+  name = "${local.project_prefix}_github_actions_role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -44,13 +44,13 @@ resource "aws_iam_role" "github_actions_role" {
     ]
   })
   tags = {
-    Name = "${var.project_prefix}_iam_github_actions_role"
+    Name = "${local.project_prefix}_iam_github_actions_role"
   }
   depends_on = [aws_iam_openid_connect_provider.github_oidc_provider]
 }
 
 resource "aws_iam_policy" "github_actions_policy" {
-  name = "${var.project_prefix}_github_actions_policy"
+  name = "${local.project_prefix}_github_actions_policy"
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
@@ -73,8 +73,8 @@ resource "aws_iam_policy" "github_actions_policy" {
           "s3:DeleteObject",
         ],
         Resource = [
-          "arn:aws:s3:::${var.terraform_remote_state_bucket}",
-          "arn:aws:s3:::${var.terraform_remote_state_bucket}/*",
+          "arn:aws:s3:::${local.terraform_remote_state_bucket}",
+          "arn:aws:s3:::${local.terraform_remote_state_bucket}/*",
           "arn:aws:s3:::${var.athena_s3_output_bucket}",
           "arn:aws:s3:::${var.athena_s3_output_bucket}/*"
         ]
@@ -120,7 +120,7 @@ resource "aws_iam_policy" "github_actions_policy" {
     ]
   })
   tags = {
-    Name = "${var.project_prefix}_iam_github_actions_policy"
+    Name = "${local.project_prefix}_iam_github_actions_policy"
   }
 }
 

--- a/terraform/github_action_oidc/locals.tf
+++ b/terraform/github_action_oidc/locals.tf
@@ -1,0 +1,11 @@
+module "common" {
+  source = "../modules/common"
+}
+
+locals {
+  project_prefix                = module.common.project_prefix
+  terraform_remote_state_bucket = module.common.terraform_remote_state_bucket
+  profile                       = module.common.profile
+  aws_region                    = module.common.aws_region
+  aws_account_id                = module.common.aws_account_id
+}

--- a/terraform/github_action_oidc/main.tf
+++ b/terraform/github_action_oidc/main.tf
@@ -9,6 +9,5 @@ terraform {
 }
 
 provider "aws" {
-  region  = var.region
-  profile = var.profile
+  profile = local.profile
 }

--- a/terraform/github_action_oidc/variables.tf
+++ b/terraform/github_action_oidc/variables.tf
@@ -1,28 +1,3 @@
-variable "region" {
-  type        = string
-  description = "AWS region where resources will be deployed"
-}
-
-variable "profile" {
-  type        = string
-  description = "AWS configuration profile with all required permissions"
-}
-
-variable "account_id" {
-  type        = string
-  description = "AWS account ID where resources will be deployed"
-}
-
-variable "project_prefix" {
-  type        = string
-  description = "Prefix to use when naming all resources for the project"
-}
-
-variable "terraform_remote_state_bucket" {
-  type        = string
-  description = "S3 bucket name for storing Terraform remote state"
-}
-
 variable "athena_s3_output_bucket" {
   type        = string
   description = "Athena is used to access tables in S3 table bucket, which requires an S3 output bucket for query results"

--- a/terraform/github_action_oidc/variables.tfvars.example
+++ b/terraform/github_action_oidc/variables.tfvars.example
@@ -1,8 +1,3 @@
-region                         = "us-east-1"
-profile                        = "aws-profile"
-account_id                     = "aws-account-id"
-project_prefix                 = "project-name"
-terraform_remote_state_bucket  = "terraform-state-bucket"
 athena_s3_output_bucket        = "athena-s3-output-bucket"
 create_github_oidc_provider    = false
 existing_oidc_provider_arn     = "arn:aws:iam::AWS-ACCOUNT-ID:oidc-provider/token.actions.githubusercontent.com"

--- a/terraform/modules/common/data.tf
+++ b/terraform/modules/common/data.tf
@@ -1,0 +1,3 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}

--- a/terraform/modules/common/locals.tf
+++ b/terraform/modules/common/locals.tf
@@ -1,0 +1,5 @@
+locals {
+    profile = "admin"
+    project_prefix = "tbills_scraper"
+    terraform_remote_state_bucket = "tf-cf-templates"
+}

--- a/terraform/modules/common/outputs.tf
+++ b/terraform/modules/common/outputs.tf
@@ -1,0 +1,24 @@
+output "aws_region" {
+  value = data.aws_region.current.region
+  description = "AWS region where resources will be deployed"
+}
+
+output "aws_account_id" {
+  value = data.aws_caller_identity.current.account_id
+  description = "AWS account ID where resources are deployed"
+}
+
+output "profile" {
+    value = local.profile
+    description = "AWS configuration profile with all required permissions"
+}
+
+output "project_prefix" {
+  value = local.project_prefix
+  description = "Prefix to use when naming all resources for the project"
+}
+
+output "terraform_remote_state_bucket" {
+  value = local.terraform_remote_state_bucket
+  description = "S3 bucket name for storing Terraform remote state"
+}

--- a/terraform/s3_table_bucket/data.tf
+++ b/terraform/s3_table_bucket/data.tf
@@ -1,0 +1,10 @@
+# Data source to get github actions role arn from remote state
+data "terraform_remote_state" "github_actions" {
+  backend = "s3"
+  config = {
+    bucket  = local.terraform_remote_state_bucket
+    key     = var.terraform_remote_state_github_actions_s3_key
+    region  = local.aws_region
+    profile = local.profile
+  }
+}

--- a/terraform/s3_table_bucket/locals.tf
+++ b/terraform/s3_table_bucket/locals.tf
@@ -1,0 +1,12 @@
+module "common" {
+  source = "../modules/common"
+}
+
+
+locals {
+  project_prefix                = module.common.project_prefix
+  terraform_remote_state_bucket = module.common.terraform_remote_state_bucket
+  profile                       = module.common.profile
+  aws_region                    = module.common.aws_region
+  aws_account_id                = module.common.aws_account_id
+}

--- a/terraform/s3_table_bucket/main.tf
+++ b/terraform/s3_table_bucket/main.tf
@@ -9,17 +9,5 @@ terraform {
 }
 
 provider "aws" {
-  region  = var.region
-  profile = var.profile
-}
-
-# Data source to get github actions role arn from remote state
-data "terraform_remote_state" "github_actions" {
-  backend = "s3"
-  config = {
-    bucket  = var.terraform_remote_state_bucket
-    key     = var.terraform_remote_state_github_actions_s3_key
-    region  = var.region
-    profile = var.profile
-  }
+  profile = local.profile
 }

--- a/terraform/s3_table_bucket/variables.tf
+++ b/terraform/s3_table_bucket/variables.tf
@@ -1,21 +1,3 @@
-variable "region" {
-  type        = string
-  description = "AWS region where resources will be deployed"
-  default     = "us-east-1"
-}
-
-variable "profile" {
-  type        = string
-  description = "AWS configuration profile with all required permissions"
-  default     = "admin"
-}
-
-variable "terraform_remote_state_bucket" {
-  type        = string
-  description = "Name of the S3 bucket where the Terraform state files are stored"
-  default     = "tf-cf-templates"
-}
-
 variable "terraform_remote_state_github_actions_s3_key" {
   type        = string
   description = "S3 key for the Terraform remote state of the GitHub Actions role created"

--- a/terraform/s3_table_bucket/variables.tfvars.example
+++ b/terraform/s3_table_bucket/variables.tfvars.example
@@ -1,8 +1,4 @@
 # AWS Configuration
-region                                       = "us-east-1"
-profile                                      = "aws-profile"
-table_bucket_name                            = "s3-tables-bucket" # Must be globally unique
-terraform_remote_state_bucket                = "terraform-remote-state-bucket" # Name of the S3 bucket for Terraform state files
 terraform_remote_state_github_actions_s3_key = "key/to/terraform.tfstate" # S3 key for the Terraform remote state of the GitHub Actions role created
 
 # See https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-setting-up.html#s3-tables-actions


### PR DESCRIPTION
## Description

Refactored Terraform configuration to eliminate repetitive boilerplate code by centralizing common values in a shared module.

## Changelog

- [ ] Python: code changes
- [ ] Python: docs/config updates
- [x] Terraform: infra changes
- [ ] Other: ___________________

### Terraform

- Created shared `modules/common/` with centralized configuration
- Added data sources for AWS region and account ID detection
- Centralized common values: profile, project_prefix, terraform_remote_state_bucket


## Checklist

### Python

- [ ] Unit tests added/updated as needed
- [ ] Tests pass locally
- [ ] Linting passes
- [ ] Typing passes

### Terraform (only if infra touched)

- [x] `terraform fmt` and `validate` pass
- [x] `terraform plan` reviewed (no unintended changes)
- [x] No secrets committed; sensitive vars handled via CI or state
